### PR TITLE
Tweak symbol mapping in vw processing

### DIFF
--- a/vw-lib/src/lib.rs
+++ b/vw-lib/src/lib.rs
@@ -1003,7 +1003,11 @@ fn parse_file_dependencies(content: &str) -> Result<Vec<VwSymbol>> {
             let name = entity_name.as_str().to_string();
             let key = format!("ent:{}", name.to_lowercase());
             if seen.insert(key) {
-                dependencies.push(VwSymbol::new(None, &name, SymbolKind::Entity));
+                dependencies.push(VwSymbol::new(
+                    None,
+                    &name,
+                    SymbolKind::Entity,
+                ));
             }
         }
     }
@@ -1017,7 +1021,11 @@ fn parse_file_dependencies(content: &str) -> Result<Vec<VwSymbol>> {
             let name = comp_name.as_str().to_string();
             let key = format!("ent:{}", name.to_lowercase());
             if seen.insert(key) {
-                dependencies.push(VwSymbol::new(None, &name, SymbolKind::Entity));
+                dependencies.push(VwSymbol::new(
+                    None,
+                    &name,
+                    SymbolKind::Entity,
+                ));
             }
         }
     }
@@ -1035,7 +1043,11 @@ fn parse_provided_symbols(content: &str) -> Result<Vec<VwSymbol>> {
 
     for captures in package_re.captures_iter(content) {
         if let Some(package_name) = captures.get(1) {
-            symbols.push(VwSymbol::new(None, package_name.as_str(), SymbolKind::Package));
+            symbols.push(VwSymbol::new(
+                None,
+                package_name.as_str(),
+                SymbolKind::Package,
+            ));
         }
     }
 
@@ -1045,7 +1057,11 @@ fn parse_provided_symbols(content: &str) -> Result<Vec<VwSymbol>> {
 
     for captures in entity_re.captures_iter(content) {
         if let Some(entity_name) = captures.get(1) {
-            symbols.push(VwSymbol::new(None, entity_name.as_str(), SymbolKind::Entity));
+            symbols.push(VwSymbol::new(
+                None,
+                entity_name.as_str(),
+                SymbolKind::Entity,
+            ));
         }
     }
 
@@ -1537,7 +1553,9 @@ fn analyze_file(
 
     for symbol in file_finder.get_symbols() {
         match symbol.kind {
-            SymbolKind::Enum(_) | SymbolKind::Record(_) | SymbolKind::Constant => {
+            SymbolKind::Enum(_)
+            | SymbolKind::Record(_)
+            | SymbolKind::Constant(_) => {
                 let name = symbol.get_name().to_string();
                 processor.symbols.insert(name.clone(), symbol.clone());
                 processor.symbol_to_file.insert(name, file_str.clone());

--- a/vw-lib/src/lib.rs
+++ b/vw-lib/src/lib.rs
@@ -41,7 +41,7 @@ use petgraph::{
     graph::{DiGraph, NodeIndex},
 };
 
-use crate::mapping::{FileData, VwSymbol, VwSymbolFinder};
+use crate::mapping::{FileData, SymbolKind, VwSymbol, VwSymbolFinder};
 use crate::nvc_helpers::{run_nvc_analysis, run_nvc_elab, run_nvc_sim};
 use crate::visitor::walk_design_file;
 
@@ -990,7 +990,7 @@ fn parse_file_dependencies(content: &str) -> Result<Vec<VwSymbol>> {
     for pkg in imports {
         let key = format!("pkg:{}", pkg.to_lowercase());
         if seen.insert(key) {
-            dependencies.push(VwSymbol::Package(pkg));
+            dependencies.push(VwSymbol::new(None, &pkg, SymbolKind::Package));
         }
     }
 
@@ -1003,7 +1003,7 @@ fn parse_file_dependencies(content: &str) -> Result<Vec<VwSymbol>> {
             let name = entity_name.as_str().to_string();
             let key = format!("ent:{}", name.to_lowercase());
             if seen.insert(key) {
-                dependencies.push(VwSymbol::Entity(name));
+                dependencies.push(VwSymbol::new(None, &name, SymbolKind::Entity));
             }
         }
     }
@@ -1017,7 +1017,7 @@ fn parse_file_dependencies(content: &str) -> Result<Vec<VwSymbol>> {
             let name = comp_name.as_str().to_string();
             let key = format!("ent:{}", name.to_lowercase());
             if seen.insert(key) {
-                dependencies.push(VwSymbol::Entity(name));
+                dependencies.push(VwSymbol::new(None, &name, SymbolKind::Entity));
             }
         }
     }
@@ -1035,7 +1035,7 @@ fn parse_provided_symbols(content: &str) -> Result<Vec<VwSymbol>> {
 
     for captures in package_re.captures_iter(content) {
         if let Some(package_name) = captures.get(1) {
-            symbols.push(VwSymbol::Package(package_name.as_str().to_string()));
+            symbols.push(VwSymbol::new(None, package_name.as_str(), SymbolKind::Package));
         }
     }
 
@@ -1045,7 +1045,7 @@ fn parse_provided_symbols(content: &str) -> Result<Vec<VwSymbol>> {
 
     for captures in entity_re.captures_iter(content) {
         if let Some(entity_name) = captures.get(1) {
-            symbols.push(VwSymbol::Entity(entity_name.as_str().to_string()));
+            symbols.push(VwSymbol::new(None, entity_name.as_str(), SymbolKind::Entity));
         }
     }
 
@@ -1408,25 +1408,25 @@ pub fn sort_files_by_dependencies(
     for file in files.iter() {
         let symbols = analyze_file(processor, file)?;
         for symbol in symbols {
-            match symbol {
-                VwSymbol::Package(name) => {
-                    all_symbols.insert(name.clone(), file.clone());
+            match &symbol.kind {
+                SymbolKind::Package => {
+                    all_symbols.insert(symbol.name.clone(), file.clone());
                     let entry = processor
                         .file_info
                         .entry(file.to_string_lossy().to_string())
                         .or_default();
-                    entry.add_defined_pkg(&name);
+                    entry.add_defined_pkg(&symbol.name);
 
                     // Use cache to get package imports only
                     let deps = cache.get_dependencies(file)?;
                     for dep in deps {
-                        if let VwSymbol::Package(pkg_name) = dep {
-                            entry.add_imported_pkg(pkg_name);
+                        if let SymbolKind::Package = dep.kind {
+                            entry.add_imported_pkg(&dep.name);
                         }
                     }
                 }
-                VwSymbol::Entity(name) => {
-                    all_symbols.insert(name, file.clone());
+                SymbolKind::Entity => {
+                    all_symbols.insert(symbol.name, file.clone());
                 }
                 _ => {}
             }
@@ -1439,8 +1439,8 @@ pub fn sort_files_by_dependencies(
         let mut file_deps = Vec::new();
 
         for dep in deps {
-            let dep_name = match &dep {
-                VwSymbol::Package(name) | VwSymbol::Entity(name) => name,
+            let dep_name = match &dep.kind {
+                SymbolKind::Package | SymbolKind::Entity => &dep.name,
                 _ => continue,
             };
             if let Some(provider_file) = all_symbols.get(dep_name) {
@@ -1507,14 +1507,14 @@ fn file_provides_symbol(
     cache: &mut FileCache,
 ) -> Result<bool> {
     let provided = cache.get_provided_symbols(file_path)?;
-    Ok(provided.iter().any(|s| match (needed, s) {
+    Ok(provided.iter().any(|s| match (&needed.kind, &s.kind) {
         // Package dependency matches package declaration
-        (VwSymbol::Package(need), VwSymbol::Package(have)) => {
-            need.eq_ignore_ascii_case(have)
+        (SymbolKind::Package, SymbolKind::Package) => {
+            needed.name.eq_ignore_ascii_case(&s.name)
         }
         // Entity dependency matches entity declaration
-        (VwSymbol::Entity(need), VwSymbol::Entity(have)) => {
-            need.eq_ignore_ascii_case(have)
+        (SymbolKind::Entity, SymbolKind::Entity) => {
+            needed.name.eq_ignore_ascii_case(&s.name)
         }
         _ => false,
     }))
@@ -1533,21 +1533,16 @@ fn analyze_file(
 
     let file_str = file.to_string_lossy().to_string();
 
-    // Add records to symbols map
-    for record in file_finder.get_records() {
-        let name = record.get_name().to_string();
-        processor
-            .symbols
-            .insert(name.clone(), VwSymbol::Record(record.clone()));
-        processor.symbol_to_file.insert(name, file_str.clone());
-    }
+    // Add symbols to the map
 
-    // Add enums from symbols (they're already VwSymbol::Enum)
     for symbol in file_finder.get_symbols() {
-        if let VwSymbol::Enum(enum_data) = symbol {
-            let name = enum_data.get_name().to_string();
-            processor.symbols.insert(name.clone(), symbol.clone());
-            processor.symbol_to_file.insert(name, file_str.clone());
+        match symbol.kind {
+            SymbolKind::Enum(_) | SymbolKind::Record(_) | SymbolKind::Constant => {
+                let name = symbol.get_name().to_string();
+                processor.symbols.insert(name.clone(), symbol.clone());
+                processor.symbol_to_file.insert(name, file_str.clone());
+            }
+            _ => {}
         }
     }
 

--- a/vw-lib/src/mapping.rs
+++ b/vw-lib/src/mapping.rs
@@ -1,34 +1,49 @@
 use vhdl_lang::ast::{
     AnyDesignUnit, AnyPrimaryUnit, AttributeSpecification, Designator,
     DiscreteRange, ElementDeclaration, EntityClass, EntityDeclaration,
-    EntityName, Name, PackageDeclaration, PackageInstantiation, Range,
-    RangeConstraint, SubtypeConstraint, TypeDeclaration, TypeDefinition,
+    EntityName, Name, ObjectClass, ObjectDeclaration, PackageDeclaration,
+    PackageInstantiation, Range, RangeConstraint, SubtypeConstraint,
+    TypeDeclaration, TypeDefinition,
 };
 
 use crate::visitor::{Visitor, VisitorResult};
 
 #[derive(Debug, Clone)]
-pub enum VwSymbol {
-    Package(String),
-    Entity(String),
-    Constant(String),
-    Record(RecordData),
-    Enum(EnumData),
+pub struct RecordFields {
+    pub fields: Vec<FieldData>,
 }
 
 #[derive(Debug, Clone)]
-pub struct EnumData {
-    pub containing_pkg: Option<String>,
-    pub name: String,
+pub struct EnumAttrs {
     pub has_custom_encoding: bool,
 }
 
-impl EnumData {
-    pub fn new(containing_pkg: Option<String>, name: &str) -> Self {
+#[derive(Debug, Clone)]
+pub enum SymbolKind {
+    Package,
+    Entity,
+    Constant,
+    Record(RecordFields),
+    Enum(EnumAttrs),
+}
+
+#[derive(Debug, Clone)]
+pub struct VwSymbol {
+    pub containing_pkg: Option<String>,
+    pub name: String,
+    pub kind: SymbolKind,
+}
+
+impl VwSymbol {
+    pub fn new(
+        containing_pkg: Option<String>,
+        name: &str,
+        kind: SymbolKind,
+    ) -> Self {
         Self {
             containing_pkg,
             name: String::from(name),
-            has_custom_encoding: false,
+            kind,
         }
     }
 
@@ -39,13 +54,14 @@ impl EnumData {
     pub fn get_name(&self) -> &str {
         &self.name
     }
-}
 
-#[derive(Debug, Clone)]
-pub struct RecordData {
-    containing_pkg: Option<String>,
-    name: String,
-    fields: Vec<FieldData>,
+    pub fn get_fields(&self) -> Option<&Vec<FieldData>> {
+        if let SymbolKind::Record(record) = &self.kind {
+            Some(&record.fields)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -75,28 +91,6 @@ impl FileData {
     }
 }
 
-impl RecordData {
-    pub fn new(containing_pkg: Option<String>, name: &str) -> Self {
-        Self {
-            containing_pkg,
-            name: String::from(name),
-            fields: Vec::new(),
-        }
-    }
-
-    pub fn get_pkg_name(&self) -> Option<&String> {
-        self.containing_pkg.as_ref()
-    }
-
-    pub fn get_fields(&self) -> &Vec<FieldData> {
-        &self.fields
-    }
-
-    pub fn get_name(&self) -> &str {
-        &self.name
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct FieldData {
     pub name: String,
@@ -107,7 +101,6 @@ pub struct FieldData {
 #[derive(Debug)]
 pub struct VwSymbolFinder {
     symbols: Vec<VwSymbol>,
-    records: Vec<RecordData>,
     tagged_types: Vec<String>,
     target_attr: String,
 }
@@ -116,7 +109,6 @@ impl VwSymbolFinder {
     pub fn new(target_attr: &str) -> Self {
         Self {
             symbols: Vec::new(),
-            records: Vec::new(),
             tagged_types: Vec::new(),
             target_attr: target_attr.to_string(),
         }
@@ -124,10 +116,6 @@ impl VwSymbolFinder {
 
     pub fn get_symbols(&self) -> &Vec<VwSymbol> {
         &self.symbols
-    }
-
-    pub fn get_records(&self) -> &Vec<RecordData> {
-        &self.records
     }
 
     pub fn get_tagged_types(&self) -> &Vec<String> {
@@ -153,9 +141,10 @@ impl Visitor for VwSymbolFinder {
                         let type_name = id.name_utf8();
                         // Find the enum and set its flag
                         for symbol in &mut self.symbols {
-                            if let VwSymbol::Enum(enum_data) = symbol {
-                                if enum_data.name == type_name {
-                                    enum_data.has_custom_encoding = true;
+                            if let SymbolKind::Enum(attrs) = &mut symbol.kind
+                            {
+                                if symbol.name == type_name {
+                                    attrs.has_custom_encoding = true;
                                     break;
                                 }
                             }
@@ -168,19 +157,49 @@ impl Visitor for VwSymbolFinder {
         // if we found the attribute with the right name
         if attr_name == self.target_attr {
             // if we tagged a type (like a record)
-            if let EntityClass::Type = spec.entity_class {
-                // get the entity name
-                if let EntityName::Name(tag) = &spec.entity_name {
-                    // get the identifier
-                    if let Designator::Identifier(id) =
-                        &tag.designator.item.item
-                    {
-                        let type_name = id.name_utf8();
-                        self.tagged_types.push(type_name);
+            match spec.entity_class {
+                EntityClass::Type | EntityClass::Constant => {
+                    // get the entity name
+                    if let EntityName::Name(tag) = &spec.entity_name {
+                        // get the identifier
+                        if let Designator::Identifier(id) =
+                            &tag.designator.item.item
+                        {
+                            let type_name = id.name_utf8();
+                            self.tagged_types.push(type_name);
+                        }
                     }
-                }
+                },
+                _ => {}
             }
         }
+        VisitorResult::Continue
+    }
+
+    fn visit_object_declaration(
+        &mut self,
+        decl: &ObjectDeclaration,
+        unit: &AnyDesignUnit,
+    ) -> VisitorResult {
+        // if this is a constant Declaration
+        if let ObjectClass::Constant = decl.class {
+            let const_name = decl.idents[0].tree.item.name_utf8();
+            // where was this constant defined
+            let def_pkg_name = if let AnyDesignUnit::Primary(
+                AnyPrimaryUnit::Package(package),
+            ) = unit
+            {
+                Some(package.ident.tree.item.name_utf8())
+            } else {
+                None
+            };
+            self.symbols.push(VwSymbol::new(
+                def_pkg_name,
+                &const_name,
+                SymbolKind::Constant,
+            ));
+        }
+
         VisitorResult::Continue
     }
 
@@ -206,15 +225,21 @@ impl Visitor for VwSymbolFinder {
 
         match &decl.def {
             TypeDefinition::Record(elements) => {
-                let mut record_struct =
-                    RecordData::new(defining_pkg_name, &name);
                 let fields = get_fields(elements);
-                record_struct.fields = fields;
-                self.records.push(record_struct);
+                self.symbols.push(VwSymbol::new(
+                    defining_pkg_name,
+                    &name,
+                    SymbolKind::Record(RecordFields { fields }),
+                ));
             }
             TypeDefinition::Enumeration(_) => {
-                let enum_data = EnumData::new(defining_pkg_name, &name);
-                self.symbols.push(VwSymbol::Enum(enum_data));
+                self.symbols.push(VwSymbol::new(
+                    defining_pkg_name,
+                    &name,
+                    SymbolKind::Enum(EnumAttrs {
+                        has_custom_encoding: false,
+                    }),
+                ));
             }
             _ => {}
         }
@@ -223,13 +248,15 @@ impl Visitor for VwSymbolFinder {
 
     fn visit_entity(&mut self, entity: &EntityDeclaration) -> VisitorResult {
         let name = entity.ident.tree.item.name_utf8();
-        self.symbols.push(VwSymbol::Entity(name));
+        self.symbols
+            .push(VwSymbol::new(None, &name, SymbolKind::Entity));
         VisitorResult::Continue
     }
 
     fn visit_package(&mut self, package: &PackageDeclaration) -> VisitorResult {
         let name = package.ident.tree.item.name_utf8();
-        self.symbols.push(VwSymbol::Package(name));
+        self.symbols
+            .push(VwSymbol::new(None, &name, SymbolKind::Package));
         VisitorResult::Continue
     }
 
@@ -238,7 +265,8 @@ impl Visitor for VwSymbolFinder {
         instance: &PackageInstantiation,
     ) -> VisitorResult {
         let name = instance.ident.tree.item.name_utf8();
-        self.symbols.push(VwSymbol::Package(name));
+        self.symbols
+            .push(VwSymbol::new(None, &name, SymbolKind::Package));
         VisitorResult::Continue
     }
 }

--- a/vw-lib/src/mapping.rs
+++ b/vw-lib/src/mapping.rs
@@ -10,6 +10,7 @@ use crate::visitor::{Visitor, VisitorResult};
 
 #[derive(Debug, Clone)]
 pub struct ConstantExpr {
+    pub type_name: Name,
     pub expression: Option<Expression>,
 }
 
@@ -200,11 +201,15 @@ impl Visitor for VwSymbolFinder {
 
             // figure out its expression
             let expr = decl.expression.as_ref().map(|span| span.item.clone());
+            let type_name = decl.subtype_indication.type_mark.item.clone();
 
             self.symbols.push(VwSymbol::new(
                 def_pkg_name,
                 &const_name,
-                SymbolKind::Constant(ConstantExpr { expression: expr }),
+                SymbolKind::Constant(ConstantExpr {
+                    type_name,
+                    expression: expr,
+                }),
             ));
         }
 

--- a/vw-lib/src/mapping.rs
+++ b/vw-lib/src/mapping.rs
@@ -1,12 +1,17 @@
 use vhdl_lang::ast::{
     AnyDesignUnit, AnyPrimaryUnit, AttributeSpecification, Designator,
     DiscreteRange, ElementDeclaration, EntityClass, EntityDeclaration,
-    EntityName, Name, ObjectClass, ObjectDeclaration, PackageDeclaration,
-    PackageInstantiation, Range, RangeConstraint, SubtypeConstraint,
-    TypeDeclaration, TypeDefinition,
+    EntityName, Expression, Name, ObjectClass, ObjectDeclaration,
+    PackageDeclaration, PackageInstantiation, Range, RangeConstraint,
+    SubtypeConstraint, TypeDeclaration, TypeDefinition,
 };
 
 use crate::visitor::{Visitor, VisitorResult};
+
+#[derive(Debug, Clone)]
+pub struct ConstantExpr {
+    pub expression: Option<Expression>,
+}
 
 #[derive(Debug, Clone)]
 pub struct RecordFields {
@@ -22,7 +27,7 @@ pub struct EnumAttrs {
 pub enum SymbolKind {
     Package,
     Entity,
-    Constant,
+    Constant(ConstantExpr),
     Record(RecordFields),
     Enum(EnumAttrs),
 }
@@ -141,8 +146,7 @@ impl Visitor for VwSymbolFinder {
                         let type_name = id.name_utf8();
                         // Find the enum and set its flag
                         for symbol in &mut self.symbols {
-                            if let SymbolKind::Enum(attrs) = &mut symbol.kind
-                            {
+                            if let SymbolKind::Enum(attrs) = &mut symbol.kind {
                                 if symbol.name == type_name {
                                     attrs.has_custom_encoding = true;
                                     break;
@@ -169,7 +173,7 @@ impl Visitor for VwSymbolFinder {
                             self.tagged_types.push(type_name);
                         }
                     }
-                },
+                }
                 _ => {}
             }
         }
@@ -193,10 +197,14 @@ impl Visitor for VwSymbolFinder {
             } else {
                 None
             };
+
+            // figure out its expression
+            let expr = decl.expression.as_ref().map(|span| span.item.clone());
+
             self.symbols.push(VwSymbol::new(
                 def_pkg_name,
                 &const_name,
-                SymbolKind::Constant,
+                SymbolKind::Constant(ConstantExpr { expression: expr }),
             ));
         }
 

--- a/vw-lib/src/visitor.rs
+++ b/vw-lib/src/visitor.rs
@@ -24,12 +24,7 @@
 //! ```
 
 use vhdl_lang::ast::{
-    AnyDesignUnit, AnyPrimaryUnit, AnySecondaryUnit, ArchitectureBody,
-    Attribute, AttributeDeclaration, AttributeSpecification,
-    ComponentDeclaration, ConfigurationDeclaration, ContextDeclaration,
-    Declaration, DesignFile, EntityDeclaration, PackageBody,
-    PackageDeclaration, PackageInstantiation, SubprogramBody,
-    SubprogramDeclaration, SubprogramInstantiation, TypeDeclaration,
+    AnyDesignUnit, AnyPrimaryUnit, AnySecondaryUnit, ArchitectureBody, Attribute, AttributeDeclaration, AttributeSpecification, ComponentDeclaration, ConfigurationDeclaration, ContextDeclaration, Declaration, DesignFile, EntityDeclaration, ObjectDeclaration, PackageBody, PackageDeclaration, PackageInstantiation, SubprogramBody, SubprogramDeclaration, SubprogramInstantiation, TypeDeclaration
 };
 
 /// Controls whether AST traversal should continue or stop.
@@ -136,6 +131,14 @@ pub trait Visitor {
     fn visit_type_declaration(
         &mut self,
         decl: &TypeDeclaration,
+        unit: &AnyDesignUnit,
+    ) -> VisitorResult {
+        VisitorResult::Continue
+    }
+
+    fn visit_object_declaration(
+        &mut self,
+        decl: &ObjectDeclaration,
         unit: &AnyDesignUnit,
     ) -> VisitorResult {
         VisitorResult::Continue
@@ -319,6 +322,7 @@ fn walk_declaration<V: Visitor>(
             visitor.visit_type_declaration(type_decl, unit)
         }
         Declaration::Component(comp) => visitor.visit_component(comp, unit),
+        Declaration::Object(obj) => visitor.visit_object_declaration(obj, unit),
         Declaration::Attribute(attr) => match attr {
             Attribute::Declaration(decl) => {
                 visitor.visit_attribute_declaration(decl, unit)

--- a/vw-lib/src/visitor.rs
+++ b/vw-lib/src/visitor.rs
@@ -24,7 +24,12 @@
 //! ```
 
 use vhdl_lang::ast::{
-    AnyDesignUnit, AnyPrimaryUnit, AnySecondaryUnit, ArchitectureBody, Attribute, AttributeDeclaration, AttributeSpecification, ComponentDeclaration, ConfigurationDeclaration, ContextDeclaration, Declaration, DesignFile, EntityDeclaration, ObjectDeclaration, PackageBody, PackageDeclaration, PackageInstantiation, SubprogramBody, SubprogramDeclaration, SubprogramInstantiation, TypeDeclaration
+    AnyDesignUnit, AnyPrimaryUnit, AnySecondaryUnit, ArchitectureBody,
+    Attribute, AttributeDeclaration, AttributeSpecification,
+    ComponentDeclaration, ConfigurationDeclaration, ContextDeclaration,
+    Declaration, DesignFile, EntityDeclaration, ObjectDeclaration, PackageBody,
+    PackageDeclaration, PackageInstantiation, SubprogramBody,
+    SubprogramDeclaration, SubprogramInstantiation, TypeDeclaration,
 };
 
 /// Controls whether AST traversal should continue or stop.


### PR DESCRIPTION
This makes symbol mapping in vw more general, so we can extract values for constants from VHDL into Rust. 