### PR TITLE
Always write out forward slashes

### DIFF
--- a/vw-lib/src/lib.rs
+++ b/vw-lib/src/lib.rs
@@ -1861,7 +1861,10 @@ fn get_cached_entities<'a>(
 fn make_path_portable(path: PathBuf) -> PathBuf {
     if let Some(home_dir) = dirs::home_dir() {
         if let Ok(relative_path) = path.strip_prefix(&home_dir) {
-            return PathBuf::from("$HOME").join(relative_path);
+            let joined = PathBuf::from("$HOME").join(relative_path);
+            // Normalize to forward slashes so files written on Windows
+            // remain readable on Linux (and vice versa).
+            return PathBuf::from(joined.to_string_lossy().replace('\\', "/"));
         }
     }
     path


### PR DESCRIPTION
Linux doesn't like back slashes in the path, but Windows doesn't mind, so convert all back slashes to forward slashes for writing out `vhdl_ls.toml`. Tested partially on Windows (ran through a normal digital test), but I don't have mixed signal tools installed.